### PR TITLE
Fix runtime crashes

### DIFF
--- a/scripts/charger.lua
+++ b/scripts/charger.lua
@@ -225,7 +225,7 @@ function model.set_burner(train, state)
     -- train.burner.remaining_burning_fuel = train.burner.currently_burning.fuel_value*state
     -- turn this into double, as its may be smthing like 0.534343 -> 0.5
     -- error: ttempt to perform arithmetic on field 'fuel_value' (a nil value)
-    train.burner.remaining_burning_fuel = train.burner.currently_burning.fuel_value*state
+    train.burner.remaining_burning_fuel = train.burner.currently_burning.name.fuel_value*state
 
 end
 
@@ -243,7 +243,7 @@ function model.has_enough_energy(charger, train)
 
     local left = 0
     if train.burner.currently_burning then
-        left = train.burner.remaining_burning_fuel/train.burner.currently_burning.fuel_value
+        left = train.burner.remaining_burning_fuel/train.burner.currently_burning.name.fuel_value
     end
 
     total_needed = total_needed*(1 - left)
@@ -485,7 +485,7 @@ function model.toggle_range_highlight(player)
         
         -- remove all renderings
         for key,_ in pairs(storage.ei_emt.gui[player_index]) do
-            rendering.destroy(key)
+            key.destroy()
         end
 
         storage.ei_emt.gui[player_index] = nil

--- a/scripts/charger.lua
+++ b/scripts/charger.lua
@@ -224,7 +224,6 @@ function model.set_burner(train, state)
     train.burner.currently_burning = prototypes.item["ei_emt-fuel_"..tostring(acc).."_"..tostring(speed)]
     -- train.burner.remaining_burning_fuel = train.burner.currently_burning.fuel_value*state
     -- turn this into double, as its may be smthing like 0.534343 -> 0.5
-    -- error: ttempt to perform arithmetic on field 'fuel_value' (a nil value)
     train.burner.remaining_burning_fuel = train.burner.currently_burning.name.fuel_value*state
 
 end


### PR DESCRIPTION
Fixes a couple runtime crashes:
- crash when an EM train is in range of a charger (the one mentioned in point 5 of https://github.com/PreLeyZero/exotic-industries/pull/81#issuecomment-2727646899)
- crash when toggling off range overlay when a charger exists

The specific issues were:
- `currently_burning` was changed to return an item+quality pair, we need to get the item out of that before operating on it
- `rendering` was reworked, its draw functions return an object instead of an id now, and we need to call `destroy()` on that object directly

(cc https://github.com/PreLeyZero/exotic-industries-trains/pull/1, so this shows up on that pr's timeline)